### PR TITLE
Add support for Brightcove Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,44 +32,57 @@ To start changing the sample, you should have two accounts:
 1. [A Brightcove VideoCloud account](https://register.brightcove.com/)
 2. [A Roku Developers account](https://developer.roku.com/developer)
 
-The Roku developers account gives you access to more sample code, in the SDK, and helpful forums.  The Brightcove VideoCloud account will be used for storing the playlists and videos in use.
-
-## Getting your content ready
-
-To add your own content to the sample, you need to do the following:
-
-1. Create a custom Brightcove player using one of the multi-playlist player templates, and at
-   least one playlist for your Roku content.
-2. Make sure each playlist has a thumbnail (304x237 pixels).
+The Roku developers account gives you access to the full SDK source, helpful forums, and information on publishing a finished channel.  The Brightcove VideoCloud account will be used for editing the playlists and videos in use.
 
 ## Configure the app
 
-The app allows you not only to use your own content but to change images, text, and themes.  Below are the files you can change and what to change in them.
+You can change a lot in the sample application without changing too much code.  There's ways to change not only the content but also the images, text, and themes.  Below are the files you can change and what to change in them.
 
 #### A. manifest
-	- title: this is the name of the app that appears on the channel list
-	- subtitle: appears beneath the title on the channel list (optional)
+- title: this is the name of the app that appears on the channel list
+- subtitle: appears beneath the title on the channel list (optional)
 
 #### B. source/Config.brs
-	1. appName: this is the name of the application, appearing in the upper right corner of the app
-	2. brightcoveToken: your Brightcove API key with read permission and URL access. This can be
-	   found in Account Settings > API Management in [VideoCloud](https://videocloud.brightcove.com)
-	3. playerID: the player ID of the custom player you created previously when getting content ready
-	4. alwaysShowCategories: if set to false, the app will not show the playlists screen if there
-	   is only one playlist. It will go straight to the video assets instead.
-	5. initTheme settings: controls the look and feel of your application. This is well documented
-	   in the Roku SDK documents
+1. appName: this is the name of the application, appearing in the upper right corner of the app
+2. useSmartPlayer: whether to use a Smart Player or Brightcove Player to retrieve playlist and video information.  Two sections below describe in detail the specific settings you need to then set for the player in use.
+3. alwaysShowPlaylists: if set to false, the app will not show the playlists screen if there is only one playlist. It will go straight to the video assets instead.
+4. initTheme settings: controls the look and feel of your application. This is well documented in the Roku SDK documents
+
+#### C. source/Config.brs for Smart Players
+
+The smart player is most people are using for their players in Brightcove (as of early 2015).  If this is what you are used to using, you can set up one of these players for use with this application:
+
+1. Create a custom smart player using one of the multi-playlist player templates, and at
+   least one playlist for your Roku content.  You can add as many playlists as you'd like
+2. You can use a thumbnail for each playlist (304x237 pixels), or the poster image of the first video in the playlist will be used for the playlist thumbnail.
+
+Once the above is set up, you can set up the player in source/Config.brs using the following settings:
+
+1. brightcoveToken: your Brightcove API key with read permission and URL access. This can be       found in Account Settings > API Management in [VideoCloud](https://videocloud.brightcove.com)
+2. playerID: the player ID of the smart player you created
+
+#### B. source/Config.brs for Brightcove Players
+
+Brightcove players are the new player from Brightcove (as of early 2015).  If you are using these players, you can also set one of them up for use with this application:
+
+1. Create a custom Brightcove player and make sure it is enabled for playlists.  In the media module, find the playlist you would like to use with it.  Copy the URL embed code for use.
+
+Once the above is set up, you can set up the player in source/Config.brs using the following settings:
+
+1. playerURL: the URL as described above which has a playlist associated with it
+
+Currently multiple playlists are not support in the Brightcove Player, and only one playlist is possible using this setup.  There is nearly-completed code in source/BrightcovePlayerAPI.brs to allow for multiple playlists using a config specific for Roku.  If you get this working, please send in a pull request!
 
 #### C. images/*.png
 
 Replace any of the following sample images with brand images:
 
-	1. Overhang_Background_HD.png (header images that appear at the top of the screen)
-	2. Overhang_Background_SD.png
-	3. mm_icon_focus_hd.png
-	4. mm_icon_focus_sd.png
-	5. mm_icon_side_hd.png
-	6. mm_icon_side_sd.png
+1. Overhang_Background_HD.png (header images that appear at the top of the screen)
+2. Overhang_Background_SD.png
+3. mm_icon_focus_hd.png
+4. mm_icon_focus_sd.png
+5. mm_icon_side_hd.png
+6. mm_icon_side_sd.png
 
 ## Making more changes ##
 

--- a/source/BrightcoveMediaAPI.brs
+++ b/source/BrightcoveMediaAPI.brs
@@ -1,5 +1,6 @@
 ''
-'' Calls to the Brightcove media API
+'' Retrieves playlist and video information that begin with a Smart Player.
+'' If you are using a Brightcove Player instead, see BrightcovePlayerAPI
 ''
 
 function BrightcoveMediaAPI()
@@ -14,7 +15,7 @@ end function
 
 function GetPlaylistConfig() as Object
   configUrl = "http://api.brightcove.com/services/library?command=find_playlists_for_player_id&player_id=" + Config().playerID +"&playlist_fields=id,name,thumbnailURL&token=" + Config().brightcoveToken
-  print "configUrl: " ; configUrl
+  'print "configUrl: " ; configUrl
   out = {
     playlists: [], thumbs: {}
   }
@@ -23,7 +24,7 @@ function GetPlaylistConfig() as Object
 
   ' Brightcove does not have multiple thumbnails for playlists, so we'll use the HD one and scale down
   for each list in playlists.items
-    print "List: " ; list.id
+    'print "List: " ; list.id
     out.playlists.push(list.id)
     out.thumbs[list.id]  = list.thumbnailurl
   next
@@ -39,7 +40,7 @@ function GetPlaylists(playlists = [], thumbs = [])
     lists = lists + playlist + ","
   next
   lists = Left(lists, Len(lists) - 1 )
-  print lists
+  'print lists
   ' Can we just grab the correct playlists?
   raw = GetStringFromURL("http://api.brightcove.com/services/library?command=find_playlists_by_ids&playlist_ids="+lists+"&playlist_fields=name,id,thumbnailurl,shortdescription,videos&video_fields=thumbnailurl,longdescription,VIDEOSTILLURL&sort_by=publish_date&sort_order=DESC&get_item_count=true&token=" + Config().brightcoveToken)
 
@@ -53,7 +54,7 @@ function GetPlaylists(playlists = [], thumbs = [])
   for each item in json.items
     'PrintAA(item)
 
-    if item <> invalid and (playlists.Count() > 0 or playlistFilter.DoesExist(ValidStr(item.id)))
+    if item <> invalid and playlists.Count() > 0 and playlistFilter.DoesExist(ValidStr(item.id))
       print "Adding playlist ";item.id
 
       newPlaylist = {
@@ -85,8 +86,6 @@ function GetVideosForPlaylist(playlistID)
   result = []
 
   ' grabbing all the data for the playlist at once can result in a huge chunk of JSON and processing that into a BS structure can crash the box
-  ' "http://api.brightcove.com/services/library?command=find_playlist_by_id&media_delivery=http&video_fields=publisheddate,tags,length,name,thumbnailurl,renditions,longdescription&playlist_id=" + playlistID + "&token=" + Config().brightcoveToken
-
   raw = GetStringFromURL("http://api.brightcove.com/services/library?command=find_playlist_by_id&media_delivery=http&video_fields=id,publisheddate,tags,length,name,thumbnailurl,shortdescription,videostillurl&playlist_id=" + playlistID + "&token=" + Config().brightcoveToken)
   ' print "Getting Videos";raw
 
@@ -120,7 +119,6 @@ function GetVideosForPlaylist(playlistID)
     date = CreateObject("roDateTime")
     date.FromSeconds(StrToI(Left(ValidStr(video.publisheddate), Len(ValidStr(video.publisheddate)) - 3)))
     newVid.releaseDate = date.asDateStringNoParam()
-    print "New Categories List"
     for each tag in video.tags
       ' print "Adding Tag ";tag
       newVid.categories.Push(ValidStr(tag))
@@ -134,10 +132,8 @@ end function
 
 sub GetRenditionsForVideo(video)
   ' grabbing all the data for the playlist at once can result in a huge chunk of JSON and processing that into a BS structure can crash the box
-  ' "http://api.brightcove.com/services/library?command=find_playlist_by_id&media_delivery=http&video_fields=publisheddate,tags,length,name,thumbnailurl,renditions,longdescription&playlist_id=" + playlistID + "&token=" + Config().brightcoveToken
-
   rendURL = "http://api.brightcove.com/services/library?command=find_video_by_id&media_delivery=http&video_fields=renditions&video_id=" + video.id + "&token=" + Config().brightcoveToken
-  print "Rendition URL: "; rendURL
+  'print "Rendition URL: "; rendURL
   raw = GetStringFromURL(rendURL)
   json = SimpleJSONParser(raw)
   'PrintAA(json)

--- a/source/BrightcoveMediaAPI.brs
+++ b/source/BrightcoveMediaAPI.brs
@@ -143,6 +143,8 @@ sub GetRenditionsForVideo(video)
   end if
 
   for each rendition in json.renditions
+    ' FIXME: allow HLS streams here?  They all may just work, but this still needs to be
+    ' tried out.  RTMP streams would still need to be excluded.
     if UCase(ValidStr(rendition.videocontainer)) = "MP4" and UCase(ValidStr(rendition.videocodec)) = "H264"
 
       newStream = {

--- a/source/BrightcovePlayerAPI.brs
+++ b/source/BrightcovePlayerAPI.brs
@@ -1,0 +1,116 @@
+'
+' Retrieves playlist and video information that begin with a Brightcove Player.
+' If you are using a Smart Player instead, see BrightcoveMediaAPI
+'
+' FIXME: handle multiple playlists (once the Brightcove Player supports this)
+
+function BrightcovePlayerAPI()
+  this = {
+    GetPlaylistData: GetPlaylistData
+  }
+  return this
+end function
+
+' FIXME: break this horribly long function into multiple functions
+function GetPlaylistData()
+  playerURL = Config().playerURL
+
+  ' find the account/publisher ID in the URL
+  accountStart = Instr(1, playerURL, "brightcove.net/") + 15
+  accountEnd = Instr(accountStart, playerURL, "/")
+  accountId = Mid(playerURL, accountStart, accountEnd - accountStart)
+  print "Using account ID "; accountId
+
+  ' find the playlist ID in the URL
+  ' FIXME: allow this to not be there, and then get the playlist data from config.json instead
+  playlistStart = Instr(1, playerURL, "playlistId=") + 11
+  playlistId = Mid(playerURL, playlistStart)
+
+  ' find the config.json URL where we can get more player details
+  repoEnd = Instr(accountEnd + 1, playerURL, "/")
+  shortenedURL = Left(playerURL, repoEnd)
+  configURL = shortenedURL + "config.json"
+  print "Getting data from " ; configURL
+
+  ' retrieve config.json
+  configData = GetStringFromURL(configURL)
+  configJson = ParseJSON(configData)
+  'printAA(configJson)
+
+  ' all we use is the policy key right now from this data
+  policyKey = configJson.video_cloud.policy_key
+
+  ' and now finally, time to get the playlist
+  print 'Getting playlist data for ' ; playlistId
+  playbackUrl = "https://edge.api.brightcove.com/playback/v1/accounts/" + accountId + "/playlists/" + playlistId
+  playlistData = GetStringFromURL(playbackUrl, policyKey)
+  playlist = ParseJSON(playlistData)
+  'printAA(playlist)
+
+  ' we only have one playlist, but we follow the format to allow for more playlists
+  out = {
+    playlists: []
+  }
+
+  ' construct the playlist details
+  rokuPlaylist = {
+    playlistID: ValidStr(playlist.id)
+    shortDescriptionLine1: ValidStr(playlist.name)
+    shortDescriptionLine2: Left(ValidStr(playlist.description), 60)
+    ' we have to choose the first video instead of using the playlist poster,
+    ' since the playlist poster is not exposed in the playback API currently
+    ' FIXME: use the https logic in BrightcoveMediaAPI for poster URLs?
+    sdPosterURL: ValidStr(playlist.videos[0].poster)
+    hdPosterURL: ValidStr(playlist.videos[0].poster)
+    content: []
+  }
+
+  ' add in the video and sources details
+  for each video in playlist.videos
+    'PrintAA(video)
+    newVid = {
+      id:                      ValidStr(video.id)
+      contentId:               ValidStr(video.id)
+      shortDescriptionLine1:   ValidStr(video.name)
+      title:                   ValidStr(video.name)
+      description:             ValidStr(video.description)
+      synopsis:                ValidStr(video.description)
+      sdPosterURL:             ValidStr(video.poster)
+      hdPosterURL:             ValidStr(video.poster)
+      length:                  Int(StrToI(ValidStr(video.length)) / 1000)
+      streams:                 []
+      streamFormat:            "mp4"
+      contentType:             "episode"
+      categories:              []
+    }
+    date = CreateObject("roDateTime")
+    date.FromISO8601String(video.published_at)
+'    date.FromSeconds(StrToI(Left(ValidStr(video.published_at, Len(ValidStr(video.published_at)) - 3)))
+    newVid.releaseDate = date.asDateStringNoParam()
+    for each tag in video.tags
+      ' print "Adding Tag ";tag
+      newVid.categories.Push(ValidStr(tag))
+    next
+    for each source in video.sources
+      if UCase(ValidStr(source.container)) = "MP4" and UCase(ValidStr(source.codec)) = "H264" and src <> invalid
+        newStream = {
+          url:  ValidStr(source.src)
+        }
+
+        if StrToI(ValidStr(source.height)) > 720
+          video.fullHD = true
+        end if
+        if StrToI(ValidStr(source.height)) > 480
+          video.isHD = true
+          video.hdBranded = true
+          newStream.quality = true
+        end if
+        newVid.streams.Push(newStream)
+      end if
+    next
+    rokuPlaylist.content.Push(newVid)
+  next
+
+  out.playlists.push(rokuPlaylist)
+  return out
+end function

--- a/source/BrightcoveVideoScreen.brs
+++ b/source/BrightcoveVideoScreen.brs
@@ -3,7 +3,7 @@
 ''
 
 Function BrightcoveVideoScreen(video As Object)
-  if video.streams.Count() = 0
+  if Config().useSmartPlayer and video.streams.Count() = 0
     BrightcoveMediaAPI().GetRenditionsForVideo(video)
   end if
   showVideoScreen(video)

--- a/source/Config.brs
+++ b/source/Config.brs
@@ -7,7 +7,7 @@ Function Config() As Object
     ' the name to show on top of screens
     appName: "Test Application"
     ' whether to use the Smart Player or Brightcove player settings below
-    useSmartPlayer: false,
+    useSmartPlayer: true,
     ' whether to show the playlist screen, even if there is only one playlist
     alwaysShowPlaylists: true
 

--- a/source/Config.brs
+++ b/source/Config.brs
@@ -6,18 +6,26 @@ Function Config() As Object
   this = {
     ' the name to show on top of screens
     appName: "Test Application"
+    ' whether to show the playlist screen, even if there is only one playlist
+    alwaysShowPlaylists: true
+
+    '' Smart Player setup: this block of config is needed when using a Smart Player
     ' media API token, which MUST be a Brightcove read token with URL access
     brightcoveToken: "1haf2aFRHkf2j4_cfBV3O0EOYDKs-0K1M-nqUT6qM1JY4zNaAvab4w.."
-    ' the player is used for its attached playlists
+    ' the smart player is used for its attached playlists
     playerID: "4201806590001"
-    ' whether to show the playlist screen, even if there is only one playlist
-    alwaysShowPlaylists: false
+
+    '' Brightcove Player setup: this block of config is needed when using a Brightcove
+    '' Player, the latest player system
+    'playerURL: "http://players.brightcove.net/2549849259001/0e39f135-a34c-490d-8a3f-631e55a60926_default/index.html?playlistId=4201918719001"
+
+    initTheme: initTheme
   }
   return this
 
 End Function
 
-Sub initTheme()
+Function initTheme()
 
   '' Theme setup, adjust to your needs.
   app = CreateObject("roAppManager")
@@ -61,4 +69,4 @@ Sub initTheme()
 
   app.SetTheme(theme)
 
-End Sub
+End Function

--- a/source/Config.brs
+++ b/source/Config.brs
@@ -6,18 +6,20 @@ Function Config() As Object
   this = {
     ' the name to show on top of screens
     appName: "Test Application"
+    ' whether to use the Smart Player or Brightcove player settings below
+    useSmartPlayer: false,
     ' whether to show the playlist screen, even if there is only one playlist
     alwaysShowPlaylists: true
 
-    '' Smart Player setup: this block of config is needed when using a Smart Player
-    ' media API token, which MUST be a Brightcove read token with URL access
+    '' Smart Player setup: this block of config is needed when using a Smart Player.
+    ' the media API token, which MUST be a Brightcove read token with URL access
     brightcoveToken: "1haf2aFRHkf2j4_cfBV3O0EOYDKs-0K1M-nqUT6qM1JY4zNaAvab4w.."
     ' the smart player is used for its attached playlists
     playerID: "4201806590001"
 
     '' Brightcove Player setup: this block of config is needed when using a Brightcove
     '' Player, the latest player system
-    'playerURL: "http://players.brightcove.net/2549849259001/0e39f135-a34c-490d-8a3f-631e55a60926_default/index.html?playlistId=4201918719001"
+    playerURL: "http://players.brightcove.net/2549849259001/0e39f135-a34c-490d-8a3f-631e55a60926_default/index.html?playlistId=4201918719001"
 
     initTheme: initTheme
   }

--- a/source/GetStringFromURL.brs
+++ b/source/GetStringFromURL.brs
@@ -3,14 +3,20 @@
 ' Modified from NWM_Utilities.brs in the Roku SDK
 '
 
-function GetStringFromURL(url, userAgent = "")
+function GetStringFromURL(url, bcovPolicy = "")
  result = ""
  timeout = 10000
 
   ut = CreateObject("roURLTransfer")
+
+  ' allow for https
+  ut.SetCertificatesFile("common:/certs/ca-bundle.crt")
+  ut.AddHeader("X-Roku-Reserved-Dev-Id", "")
+  ut.InitClientCertificates()
+
   ut.SetPort(CreateObject("roMessagePort"))
-  if userAgent <> ""
-  ut.AddHeader("user-agent", userAgent)
+  if bcovPolicy <> ""
+    ut.AddHeader("BCOV-Policy", bcovPolicy)
   end if
   ut.SetURL(url)
   if ut.AsyncGetToString()

--- a/source/HomeScreen.brs
+++ b/source/HomeScreen.brs
@@ -14,7 +14,7 @@ sub HomeScreen(breadLeft, breadRight, playlists, thumbs)
 
   ' get the playlist data if needed
   bcConfig = Config()
-  if bcConfig.playerURL = invalid
+  if bcConfig.useSmartPlayer
     bc = BrightcoveMediaAPI()
     content = bc.GetPlaylists(playlists, thumbs)
     if content = invalid or content.count() = 0

--- a/source/HomeScreen.brs
+++ b/source/HomeScreen.brs
@@ -12,18 +12,24 @@ sub HomeScreen(breadLeft, breadRight, playlists, thumbs)
   screen.SetBreadcrumbText(breadLeft, breadRight)
   screen.Show()
 
-  bc = BrightcoveMediaAPI()
-  content = bc.GetPlaylists(playlists, thumbs)
-  if content = invalid or content.count() = 0
-    '' from roku-sdk/dialogs
-    ShowConnectionFailed()
-    return
+  ' get the playlist data if needed
+  bcConfig = Config()
+  if bcConfig.playerURL = invalid
+    bc = BrightcoveMediaAPI()
+    content = bc.GetPlaylists(playlists, thumbs)
+    if content = invalid or content.count() = 0
+      '' from roku-sdk/dialogs
+      ShowConnectionFailed()
+      return
+    end if
+  else
+    content = playlists
   end if
 
   ' let's not show playlists if there's only one
-  if content.count() = 1 and Config().alwaysShowPlaylists = false
+  if content.count() = 1 and bcConfig.alwaysShowPlaylists = false
     selectedItem = content[0]
-    PlaylistScreen(selectedItem, Config().appName, selectedItem.shortDescriptionLine1)
+    PlaylistScreen(selectedItem, bcConfig.appName, selectedItem.shortDescriptionLine1)
   else
     screen.SetContentList(content)
     screen.Show()
@@ -36,7 +42,7 @@ sub HomeScreen(breadLeft, breadRight, playlists, thumbs)
           exit while
         else if msg.isListItemSelected()
           selectedItem = content[msg.Getindex()]
-          PlaylistScreen(selectedItem, Config().appName, selectedItem.shortDescriptionLine1)
+          PlaylistScreen(selectedItem, bcConfig.appName, selectedItem.shortDescriptionLine1)
         end if
       end if
     end while

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -4,8 +4,9 @@
 ''
 
 sub Main()
-  ' from Config, first initialize any theme settings
-  initTheme()
+  ' first initialize any theme settings
+  bcConfig = Config()
+  bcConfig.initTheme()
 
   ' set the simple loading screen
   screenFacade = CreateObject("roPosterScreen")
@@ -13,19 +14,27 @@ sub Main()
   screenFacade.show()
 
   ' show the title
-  screenFacade.SetBreadcrumbText(Config().appName, "")
+  screenFacade.SetBreadcrumbText(bcConfig.appName, "")
 
   ' get playlist data from Brightcove
-  json = BrightcoveMediaAPI().GetPlaylistConfig()
-  if json = invalid or type(json.playlists) <> "roArray" or json.playlists.count() = 0
+  if bcConfig.playerURL = invalid
+    playlistData = BrightcoveMediaAPI().GetPlaylistConfig()
+  else
+    playlistData = BrightcovePlayerAPI().GetPlaylistData()
+  end if
+
+  ' show an error if the initial data call went wrong, which either means Config
+  ' is incorrect or Brightcove is having issues
+  if playlistData = invalid or type(playlistData.playlists) <> "roArray" or playlistData.playlists.count() = 0
     '' From roku-sdk/dialogs
     ShowConnectionFailed()
   else
-    ' from rok-sdk/generalUtils
-    PrintAA(json)
+    print "Found "; playlistData.playlists.count(); " playlists to display"
+    ' PrintAA(playlistData)
     ' use the data from Brightcove to show the home screen
-    HomeScreen(Config().appName, "", json.playlists, json.thumbs)
+    HomeScreen(bcConfig.appName, "", playlistData.playlists, playlistData.thumbs)
   end if
+  ' we are now able to remove the loading message
   screenFacade.showMessage("")
   sleep(25)
 end sub

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -17,7 +17,7 @@ sub Main()
   screenFacade.SetBreadcrumbText(bcConfig.appName, "")
 
   ' get playlist data from Brightcove
-  if bcConfig.playerURL = invalid
+  if bcConfig.useSmartPlayer
     playlistData = BrightcoveMediaAPI().GetPlaylistConfig()
   else
     playlistData = BrightcovePlayerAPI().GetPlaylistData()

--- a/source/PlaylistScreen.brs
+++ b/source/PlaylistScreen.brs
@@ -12,7 +12,7 @@ sub PlaylistScreen(show, leftBread, rightBread)
 
   ' get the playlist content if needed
   bcConfig = Config()
-  if bcConfig.playerURL = invalid
+  if bcConfig.useSmartPlayer
     bc = BrightcoveMediaAPI()
     content = bc.GetVideosForPlaylist(show.playlistID)
     if content = invalid or content.count() = 0

--- a/source/PlaylistScreen.brs
+++ b/source/PlaylistScreen.brs
@@ -10,12 +10,19 @@ sub PlaylistScreen(show, leftBread, rightBread)
   screen.SetBreadcrumbText(leftBread, rightBread)
   screen.Show()
 
-  bc = BrightcoveMediaAPI()
-  content = bc.GetVideosForPlaylist(show.playlistID)
-  if content = invalid or content.count() = 0
-    ShowConnectionFailed()
-    return
+  ' get the playlist content if needed
+  bcConfig = Config()
+  if bcConfig.playerURL = invalid
+    bc = BrightcoveMediaAPI()
+    content = bc.GetVideosForPlaylist(show.playlistID)
+    if content = invalid or content.count() = 0
+      ShowConnectionFailed()
+      return
+    end if
+  else
+    content = show.content
   end if
+
   selectedVideo = 0
   screen.SetContentList(content)
   screen.Show()

--- a/source/SimpleJSONParser.brs
+++ b/source/SimpleJSONParser.brs
@@ -2,6 +2,7 @@
 ' SimpleJSONParser is adapted from code contributed by the Roku developer community:
 ' http://forums.roku.com/viewtopic.php?f=34&t=32208
 '
+' FIXME: use the built-in ParseJSON() in all places instead of this
 
 Function SimpleJSONParser(jsonString As String) As Object
   q = chr(34)


### PR DESCRIPTION
Add support for using the Brightcove Player (instead of the smart player) and a few misc fixups.  The details:
- Update README to include info for Brightcove Player usage
- add BrightcovePlayerAPI.brs to do the Brightcove Player equivalent of BrightcoveMediaAPI.brs.  Uses Config.playerURL
- update GetStringFromURL to work with HTTPS and to use the header needed with edge API
- add Config.useSmartPlayer for easy switching from the two players types
- Add a few more misc comments and add a few misc FIXMEs
- print out less by default
- fix issue with media API logic for filtering playlists