### PR TITLE
Update for correct upcoming name for bitrate value

### DIFF
--- a/source/BrightcovePlayerAPI.brs
+++ b/source/BrightcovePlayerAPI.brs
@@ -134,7 +134,7 @@ print playbackUrl
       if UCase(ValidStr(source.container)) = "MP4" and UCase(ValidStr(source.codec)) = "H264" and source.src <> invalid
         newStream = {
           url:  ValidStr(source.src)
-          bitrate: Int(StrToI(ValidStr(source.encoding_rate)) / 1000)
+          bitrate: Int(StrToI(ValidStr(source.avg_bitrate)) / 1000)
         }
 
         if StrToI(ValidStr(source.height)) > 720


### PR DESCRIPTION
While this is the correct name in the Media API, it's not the correct name in the playback API