### PR TITLE
replaces all SimpleJSONParser calls to ParseJSON

### DIFF
--- a/source/BrightcoveMediaAPI.brs
+++ b/source/BrightcoveMediaAPI.brs
@@ -20,7 +20,7 @@ function GetPlaylistConfig() as Object
     playlists: [], thumbs: {}
   }
   raw = GetStringFromURL(configUrl)
-  playlists = SimpleJSONParser(raw)
+  playlists = ParseJSON(raw)
 
   ' Brightcove does not have multiple thumbnails for playlists, so we'll use the HD one and scale down
   for each list in playlists.items
@@ -45,7 +45,7 @@ function GetPlaylists(playlists = [], thumbs = [])
   raw = GetStringFromURL("http://api.brightcove.com/services/library?command=find_playlists_by_ids&playlist_ids="+lists+"&playlist_fields=name,id,thumbnailurl,shortdescription,videos&video_fields=thumbnailurl,longdescription,VIDEOSTILLURL&sort_by=publish_date&sort_order=DESC&get_item_count=true&token=" + Config().brightcoveToken)
 
   ' print "Getting Playlists\n";raw
-  json = SimpleJSONParser(raw)
+  json = ParseJSON(raw)
 
   if json = invalid then
     return false
@@ -89,7 +89,7 @@ function GetVideosForPlaylist(playlistID)
   raw = GetStringFromURL("http://api.brightcove.com/services/library?command=find_playlist_by_id&media_delivery=http&video_fields=id,publisheddate,tags,length,name,thumbnailurl,shortdescription,videostillurl&playlist_id=" + playlistID + "&token=" + Config().brightcoveToken)
   ' print "Getting Videos";raw
 
-  json = SimpleJSONParser(raw)
+  json = ParseJSON(raw)
 
   if json = invalid then
     return false
@@ -135,7 +135,7 @@ sub GetRenditionsForVideo(video)
   rendURL = "http://api.brightcove.com/services/library?command=find_video_by_id&media_delivery=http&video_fields=renditions&video_id=" + video.id + "&token=" + Config().brightcoveToken
   'print "Rendition URL: "; rendURL
   raw = GetStringFromURL(rendURL)
-  json = SimpleJSONParser(raw)
+  json = ParseJSON(raw)
   'PrintAA(json)
 
   if json = invalid then

--- a/source/BrightcovePlayerAPI.brs
+++ b/source/BrightcovePlayerAPI.brs
@@ -37,7 +37,7 @@ function GetPlaylistData()
 
   ' retrieve config.json
   configData = GetStringFromURL(configURL)
-  configJson = SimpleJSONParser(configData)
+  configJson = ParseJSON(configData)
   PrintAA(configJson)
 
   ' get the policy key used for getting more playlist/video info

--- a/source/GetStringFromURL.brs
+++ b/source/GetStringFromURL.brs
@@ -4,9 +4,6 @@
 '
 
 function GetStringFromURL(url, bcovPolicy = "")
- result = ""
- timeout = 10000
-
   ut = CreateObject("roURLTransfer")
 
   ' allow for https
@@ -14,25 +11,9 @@ function GetStringFromURL(url, bcovPolicy = "")
   ut.AddHeader("X-Roku-Reserved-Dev-Id", "")
   ut.InitClientCertificates()
 
-  ut.SetPort(CreateObject("roMessagePort"))
   if bcovPolicy <> ""
     ut.AddHeader("BCOV-Policy", bcovPolicy)
   end if
   ut.SetURL(url)
-  if ut.AsyncGetToString()
-    event = wait(timeout, ut.GetPort())
-    if type(event) = "roUrlEvent"
-      print ValidStr(event.GetResponseCode())
-      result = event.GetString()
-    elseif event = invalid
-      ut.AsyncCancel()
-      ' reset the connection on timeouts
-      'ut = CreateURLTransferObject(url)
-      'timeout = 2 * timeout
-    else
-      print "roUrlTransfer::AsyncGetToString(): unknown event"
-    endif
-  end if
-
-  return result
+  return ur.GetToString()
 end function

--- a/source/SimpleJSONParser.brs
+++ b/source/SimpleJSONParser.brs
@@ -5,6 +5,7 @@
 ' FIXME: use the built-in ParseJSON() in all places instead of this
 
 Function SimpleJSONParser(jsonString As String) As Object
+  return ParseJSON(jsonString) ' in Case i missed some of replacements;
   q = chr(34)
   beforeKey  = "[,{]"
   keyFiller  = "[^:]*?"


### PR DESCRIPTION
This is simple, but I saw a FIXME comment. Also left one new line in SimpleJSONParser() that just returns ParseJSON(), just in case.